### PR TITLE
Add License field to PackageInfo.g

### DIFF
--- a/PackageInfo.in.g
+++ b/PackageInfo.in.g
@@ -12,8 +12,8 @@ SetPackageInfo( rec(
 PackageName := "CRISP",
 Subtitle := "Computing with Radicals, Injectors, Schunck classes and Projectors",
 Version := "CRISP_VERSION",
-
 Date := "CRISP_DATE",
+License := "BSD-2-Clause",
 
 BannerString := "\
 ----------------------------------------------------------------------\n\


### PR DESCRIPTION
... so that in future versions of this package, the license can be automatically detected by tools used by downstream GAP distributions, if desired (e.g. Debian)