### PR TITLE
Avoid using InstallValue on non-plain objects (take 2)

### DIFF
--- a/PackageInfo.in.g
+++ b/PackageInfo.in.g
@@ -86,7 +86,7 @@ PackageDoc := rec(
 Dependencies := rec(
   # GAP version, use version strings for specifying exact versions,
   # prepend a '>=' for specifying a least version.
-  GAP := ">=4.5",
+  GAP := ">=4.12",
   # NeededOtherPackages := [["GAPDoc", ">= 0.99"]],
   NeededOtherPackages := [],
   SuggestedOtherPackages := [],

--- a/lib/samples.gd
+++ b/lib/samples.gd
@@ -10,14 +10,14 @@
 ##  
 #V  TrivialGroups
 ##
-DeclareGlobalVariable("TrivialGroups");
+DeclareGlobalName("TrivialGroups");
 
 
 #############################################################################
 ##  
 #V  NilpotentGroups
 ##
-DeclareGlobalVariable("NilpotentGroups");
+DeclareGlobalName("NilpotentGroups");
 
 
 #############################################################################
@@ -31,8 +31,7 @@ DeclareAttribute("NilpotentProjector", IsGroup);
 ##
 #V  SupersolubleGroups
 ##
-DeclareGlobalVariable("SupersolubleGroups");
-DeclareSynonym("SupersolvableGroups", SupersolubleGroups);
+DeclareGlobalName("SupersolubleGroups");
 
 #############################################################################
 ##
@@ -46,7 +45,7 @@ DeclareSynonymAttr("SupersolvableProjector", SupersolubleProjector);
 ##
 #V  AbelianGroups
 ##
-DeclareGlobalVariable("AbelianGroups");
+DeclareGlobalName("AbelianGroups");
 
 
 #############################################################################
@@ -74,7 +73,7 @@ DeclareGlobalFunction("PGroups");
 ##
 #V  AllPrimes
 ##
-DeclareGlobalVariable("AllPrimes");
+DeclareGlobalName("AllPrimes");
 
 
 ############################################################################

--- a/lib/samples.gi
+++ b/lib/samples.gi
@@ -10,7 +10,7 @@
 ##  
 #V  AllPrimes
 ##
-InstallValue(AllPrimes, Class(x -> IsInt(x) and IsPrimeInt(x)));
+BindGlobal("AllPrimes", Class(x -> IsInt(x) and IsPrimeInt(x)));
 SetName(AllPrimes, "<set of all primes>");
 
 
@@ -18,7 +18,7 @@ SetName(AllPrimes, "<set of all primes>");
 ##  
 #V  TrivialGroups
 ##
-InstallValue(TrivialGroups, SaturatedFittingFormation( rec(
+BindGlobal("TrivialGroups", SaturatedFittingFormation( rec(
     \in := IsTrivial,
     rad := TrivialSubgroup,
     res := G -> G,
@@ -35,7 +35,7 @@ SetName(TrivialGroups, "<class of all trivial groups>");
 ##  
 #V  NilpotentGroups
 ##
-InstallValue(NilpotentGroups, SaturatedFittingFormation( rec(
+BindGlobal("NilpotentGroups", SaturatedFittingFormation( rec(
     \in := IsNilpotentGroup,
     rad := FittingSubgroup,
     res := G -> NormalClosure(G, 
@@ -88,7 +88,7 @@ CRISP_RedispatchOnCondition(NilpotentProjector,
 ##
 #V  SupersolubleGroups
 ##
-InstallValue(SupersolubleGroups, SaturatedFormation( rec(
+BindGlobal("SupersolubleGroups", SaturatedFormation( rec(
     res := SupersolvableResiduum,
     proj := SupersolubleProjector,
     locdef := function(G, p) 
@@ -108,6 +108,7 @@ InstallValue(SupersolubleGroups, SaturatedFormation( rec(
 SetIsSubgroupClosed(SupersolubleGroups, true);
 SetName(SupersolubleGroups, "<class of all supersoluble groups>");
 
+DeclareSynonym("SupersolvableGroups", SupersolubleGroups);
 
 #############################################################################
 ##  
@@ -142,7 +143,7 @@ CRISP_RedispatchOnCondition(SupersolubleProjector,
 ##
 #V  AbelianGroups
 ##
-InstallValue(AbelianGroups, OrdinaryFormation( rec(
+BindGlobal("AbelianGroups", OrdinaryFormation( rec(
     res := DerivedSubgroup,
     char := AllPrimes
     )));


### PR DESCRIPTION
I just realized that my PR #9 was rejected by @bh11 in March.

So here is a bit longer explanation. I hope this time it will not be closed outright with at least some discussion, as it would be unfortunate if loading crisp in a future GAP version would produce user facing warnings.

The pair DeclareGlobalVariable / InstallValue in GAP has unfixable design issues and arguably should never have been added in the first place, but that ship has sailed.

The main issue with these functions is with non-plain objects being used as value. In practice that means using values which are plain lists, plain records or string objects is acceptable (though still undesirable). But using a component or positional objects requires a change of the internal representation of the placeholder that e.g. prevents safe use in a multi threaded GAP. Future GAP versions will therefore issues warnings when code uses InstallValue to do that.

Luckily in many cases it suffices to use BindGlobal. In some cases one needs to make the name of the variable known to the system before declaring it. For that, one can use DeclareGlobalName (introduced in GAP 4.12). This only leaves code that really tries to access the object before an actual value has been set. Most such uses are dangerous. In the case of this package, it only affected a DeclareSynonym call, where it is safe in plain GAP but not in multi-threaded GAP.